### PR TITLE
Add Note when creating the Bridging Header

### DIFF
--- a/docs/04_iOS_SDK/01_Integrating_iOS_SDK.md
+++ b/docs/04_iOS_SDK/01_Integrating_iOS_SDK.md
@@ -179,6 +179,10 @@ You get to:
           </ul>
 
           <pre><code class=" hljs java">#<span class="hljs-keyword">import</span> <span class="hljs-string">"TestFairy.h"</span></code></pre>
+	  <p>NOTE: If framework wasn't uploaded manually please try:</p>
+	  <pre><code class=" hljs java">#<span class="hljs-keyword">import</span> <span class="hljs-string">"TestFairy/TestFairy.h"</span></code></pre>
+
+	 
 
           <p>Update Build Settings with the new bridging header:</p>
 


### PR DESCRIPTION
If TestFairy framework is downloaded from a Package Manager it needs to be referenced differently (at least this was my experience using SPM on XCode 12.4)