### PR TITLE
add file name to android allowed file types

### DIFF
--- a/docs/010_Getting_Started/300_Upload_Apps.md
+++ b/docs/010_Getting_Started/300_Upload_Apps.md
@@ -15,7 +15,7 @@ The code of our command line uploader, Jenkins plugin, and Gradle plugin is open
 
 ### Supported Plaforms
 
-  * **Android**: TestFairy supports uploading and distributing Android Applications. In order to distribute Android apps with TestFairy, they must be packaged as an `.apk` file.
+  * **Android**: TestFairy supports uploading and distributing Android Applications. In order to distribute Android apps with TestFairy, they must be packaged as an `.apk` or `.aab` file.
   * **iOS**: TestFairy supports uploading and distributing iOS applications. iOS apps can be signed with __AdHoc__, __Development__, or __Enterprise__ certificates. To distribute iOS apps with TestFairy, they must be packaged as an `.ipa` file.
   * **MacOS**: MacOS apps are bundled as `.app` files, however, to distribute MacOS apps with TestFairy, those `.app` files must be zipped into a `.zip` file.
 


### PR DESCRIPTION
We support .aab uploads, making this consistent in the documentation https://testfairy.com/blog/android-app-bundle-how-to-generate-apk-from-aab/ Our file uploader also shows that it's supported